### PR TITLE
added surf_qpt_qpt_map.set_values(-1) in geometry.h

### DIFF
--- a/src/geometry/geometry.h
+++ b/src/geometry/geometry.h
@@ -80,6 +80,8 @@ inline void build_quadrature_point_connectivity(const swage::Mesh_t& Mesh,
                                                 CArrayKokkos<int>& surf_qpt_qpt_map,
                                                 const DCArrayKokkos<double>& node_coords){
 
+    surf_qpt_qpt_map.set_values(-1);
+                                                    
     const size_t elem_dims = RefSurf.elem_dims;
     const size_t num_surfs = surf_qpt_qpt_map.dims(0);
     const size_t num_nodes_in_elem = Mesh.num_nodes_in_elem;


### PR DESCRIPTION
# Description
Quick patch to initialize surf_qpt_qpt_map.set_values(-1); inside geometry.h file, ensuring ease of use when building quadrature point connectivity on the surface.  It's not a bug, but I'll mark it as such since users are unlikely to know they must initialize the array to -1.

## Type of change

Please select all relevant options

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Formatting and/or style fixes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [X] Test A :   DG remap test

**Test Configuration**:
* OS version:  Mac
* Hardware: M2
* Compiler: clang

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] The code builds from scratch with my new changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
